### PR TITLE
Decodeur / Route pour callbacks SIGFOX

### DIFF
--- a/decoder/.gitignore
+++ b/decoder/.gitignore
@@ -1,0 +1,2 @@
+activity.log
+.vscode

--- a/decoder/Pipfile
+++ b/decoder/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+flask = "*"
+flask-api = "*"
+requests = "*"
+
+[requires]
+python_version = "3.7"

--- a/decoder/Pipfile.lock
+++ b/decoder/Pipfile.lock
@@ -1,0 +1,134 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "1a41b1ed5cd9fb8dc9229b82868f4f7b9bc2042094b680e08ed4c36b92b776dc"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+            ],
+            "version": "==2019.6.16"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "version": "==7.0"
+        },
+        "flask": {
+            "hashes": [
+                "sha256:13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52",
+                "sha256:45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"
+            ],
+            "index": "pypi",
+            "version": "==1.1.1"
+        },
+        "flask-api": {
+            "hashes": [
+                "sha256:7340db47560883b342f9965d43435eeaf595c2d30e9fc0fe48d37aab4c03942e",
+                "sha256:c0142c53fc4053d866ff3f449dd7f43b4737b6d9a70e5a77fa2b9aaf68bb4364"
+            ],
+            "index": "pypi",
+            "version": "==1.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "itsdangerous": {
+            "hashes": [
+                "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
+                "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
+            ],
+            "version": "==1.1.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
+            ],
+            "version": "==2.10.1"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
+            ],
+            "version": "==1.1.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+            ],
+            "index": "pypi",
+            "version": "==2.22.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+            ],
+            "version": "==1.25.3"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:865856ebb55c4dcd0630cdd8f3331a1847a819dda7e8c750d3db6f2aa6c0209c",
+                "sha256:a0b915f0815982fb2a09161cb8f31708052d0951c3ba433ccc5e1aa276507ca6"
+            ],
+            "version": "==0.15.4"
+        }
+    },
+    "develop": {}
+}

--- a/decoder/README.md
+++ b/decoder/README.md
@@ -1,0 +1,11 @@
+# Decoder
+
+Ce microservice consiste à exposer une route appelée par la callback Sigfox, pour acquérir les trames du transmetteur puis les interpréter pour en obtenir les informations
+
+## app.py
+
+Cette API reçoit les trame en en provenance du back-end Sigfox, les déchiffre puis stock toutes les informations présentes dans un fichier de log `activity.log`
+
+### POST /decode
+
+Reçoit la trame en provenance du back-end Sigfox et stock toutes les informations obtenues dans `activity.log`

--- a/decoder/app.py
+++ b/decoder/app.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from flask import request
+from flask_api import FlaskAPI, status
+import json
+import logging
+from logging.handlers import RotatingFileHandler
+from decoder import Decoder
+import requests
+
+app = FlaskAPI(__name__)
+_host = '0.0.0.0'
+_port = 5000
+_appDebug = False
+_DBNAME = 'db.json'
+l = 42
+
+@app.route('/decode', methods=['POST'])
+def decode():
+    l.debug("/decode :: data received :: {}".format(request.data))
+    
+    if set(("id","time", "data")) <= request.data.keys():
+        trame = Decoder(request.data["data"])
+        datas = trame.getDatas()
+        toAdd = {"device_id" : request.data["id"], "timestamp" : request.data["time"]}
+        datas.update(toAdd)
+        
+        # requests.post(url, json=json.dumps(datas))
+        l.info("datas :: {}".format(datas))
+        return '', status.HTTP_200_OK
+    else:
+        return '', status.HTTP_409_CONFLICT
+    return '', status.HTTP_417_EXPECTATION_FAILED
+
+def initLog(level=logging.DEBUG):
+    # création de l'objet logger qui va nous servir à écrire dans les logs
+    global l
+
+    l = logging.getLogger()
+    l.setLevel(level)
+    
+    formatter = logging.Formatter('%(asctime)s :: %(levelname)s :: %(message)s')
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.DEBUG)
+    stream_handler.setFormatter(formatter)
+    l.addHandler(stream_handler)
+
+    file_handler = RotatingFileHandler('activity.log', 'a', 1000000, 1)
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(formatter)
+    l.addHandler(file_handler)
+
+if __name__ == '__main__':
+    initLog()
+    app.run(host=_host, port=_port, debug=_appDebug)

--- a/decoder/decoder.py
+++ b/decoder/decoder.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import logging
+
+class Decoder:
+    '''
+        Cette classe decode une trame de sigfox
+        Elle rend accessible les informations decodées au moyen du getter getDatas()
+        Son constructeur prend directement en parametres les strings de la trame sigfox
+    '''
+
+
+    def __init__(self, trame, debug=False):
+        self._datas = {}
+        self._trame = bytes.fromhex(trame)
+        self._payloadType = 0
+
+        # Referencement des data extractables
+        self._dataInfos = {
+            "Downlink" :    (self._trame, 0b100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000),
+            "Turbidity" :   (self._trame, 0b011111111111000000000000000000000000000000000000000000000000000000000000000000000000000000000000),
+            "GPSLat" :      (self._trame, 0b000000000000111111111111111111110000000000000000000000000000000000000000000000000000000000000000),
+            "Acceleration" :(self._trame, 0b000000000000000000000000000000001110000000000000000000000000000000000000000000000000000000000000),
+            "GPSLong" :     (self._trame, 0b000000000000000000000000000000000001111111111111111111000000000000000000000000000000000000000000),
+            "GPSLongSign" : (self._trame, 0b000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000),
+            "GPSlatSign" :  (self._trame, 0b000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000),
+            "pH" :          (self._trame, 0b000000000000000000000000000000000000000000000000000000001111111000000000000000000000000000000000),
+            "InnerWater" :  (self._trame, 0b000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000),
+            "Pression" :    (self._trame, 0b000000000000000000000000000000000000000000000000000000000000000011111111111110000000000000000000),
+            "Conductance" : (self._trame, 0b000000000000000000000000000000000000000000000000000000000000000000000000000001111111111100000000),
+            "Temperature" : (self._trame, 0b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011111110),
+            "OuterWater" :  (self._trame, 0b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001)
+        }
+
+        # Initialisation du logger
+        if (debug):
+            self._initLog()
+        else:
+            self._initLog(logging.WARNING)
+
+        self._decodeSpecific()
+
+    def _decodeSpecific(self):
+        '''
+            Appelle la fonction correspondant au type de package
+        '''
+        switcher = {
+            0 : self._decodeType0
+        }
+
+        func = switcher.get(0, lambda : "Type de trame invalide") #self._payloadType a calculer et mettre a la place de 0 pour plus de payloadType
+        return func()
+
+    def _decodeType0(self):
+        self._decodeData("Downlink", self._dataInfos["Downlink"])
+        self._decodeData("Turbidity", self._dataInfos["Turbidity"])
+        self._decodeData("GPSLat", self._dataInfos["GPSLat"])
+        self._decodeData("Acceleration", self._dataInfos["Acceleration"])
+        self._decodeData("GPSLong", self._dataInfos["GPSLong"])
+        self._decodeData("GPSLongSign", self._dataInfos["GPSLongSign"])
+        self._decodeData("GPSlatSign", self._dataInfos["GPSlatSign"])
+        self._decodeData("pH", self._dataInfos["pH"])
+        self._decodeData("InnerWater", self._dataInfos["InnerWater"])
+        self._decodeData("Pression", self._dataInfos["Pression"])
+        self._decodeData("Conductance", self._dataInfos["Conductance"])
+        self._decodeData("Temperature", self._dataInfos["Temperature"])
+        self._decodeData("OuterWater", self._dataInfos["OuterWater"])
+
+    def _decodeData(self, key, dataInfo):
+        #self.datas[key] = self._getDecWithMask(self.trame[-1], 0xFF)
+        self._datas[key] = self._getDecWithMask(dataInfo[0], dataInfo[1])
+        self.logger.debug("{} :: {}".format(key, self._datas[key]))
+
+    def getDatas(self):
+        '''
+            Cette fonction renvoi un dictionnaire qui contient toutes les données
+            extraites, selon le type de trame
+        '''
+        return self._datas
+
+    def _getDecWithMask(self, byte, mask):
+        '''
+            Cette fonction retourne la valeur decimale des bits selectionnes d'un byte
+            par le masque transmis en paramètre
+            byte est de type 'int' ou 'bytes'
+            mask est de type 'int'
+        '''
+        if (mask == 0):
+            return None
+
+        if (isinstance(byte, bytes)):
+            byte = int.from_bytes(byte, byteorder='little')
+
+        dec = byte & mask
+        while (mask & 1 == 0):
+            mask = mask >> 1
+            dec  = dec >> 1
+        return dec
+
+    # création de l'objet logger qui va nous servir à écrire dans les logs
+    def _initLog(self, level=logging.DEBUG):
+        self.logger = logging.getLogger()
+
+# Pour tester
+if (__name__ == "__main__"):
+    trame = "C1FBF34FBB464A4D3456F747"
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s :: %(levelname)s :: %(message)s')
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.DEBUG)
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    inst = Decoder(trame)

--- a/decoder/dockerfile
+++ b/decoder/dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:latest
+MAINTAINER Marc PASTOR-ABAD "pastor_m@etna-alternance.net"
+RUN apt-get update -y \
+    && apt-get install -y python3-pip python3 build-essential
+COPY . /app
+WORKDIR /app
+RUN pip3 install -r requirements.txt
+ENTRYPOINT ["python3"]
+CMD ["app.py"]

--- a/decoder/requirements.txt
+++ b/decoder/requirements.txt
@@ -1,0 +1,12 @@
+certifi==2019.6.16
+chardet==3.0.4
+Click==7.0
+Flask==1.1.1
+Flask-API==1.1
+idna==2.8
+itsdangerous==1.1.0
+Jinja2==2.10.1
+MarkupSafe==1.1.1
+requests==2.22.0
+urllib3==1.25.3
+Werkzeug==0.15.4


### PR DESCRIPTION
De quoi exposer une route POST /decode aux callback de sigfox, qui dump dans `activity.log` les datas extraites

parametré selon le format "1 trame pour toutes les donnees" de la fiche technique de conception

pour injecter ces datas dans une BDD, il faut rajouter un connecteur dans les dependance, se connecter  et faire le push dans app.py:L29